### PR TITLE
Add support for BungeeCord versions after August 2016

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AdvancedBungeeAnnouncer.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AdvancedBungeeAnnouncer.java
@@ -36,9 +36,4 @@ public class AdvancedBungeeAnnouncer extends Plugin
         getProxy().getScheduler().schedule(this, new AnnouncingTask(), 1, 1, TimeUnit.SECONDS);
     }
 
-    @Override
-    public void onDisable()
-    {
-        configuration.saveAnnouncements();
-    }
 }

--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AnnouncerCommand.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AnnouncerCommand.java
@@ -71,6 +71,7 @@ public class AnnouncerCommand extends Command
                 Announcement announcement = new Announcement(message);
                 announcement.getServers().addAll(servers);
                 AdvancedBungeeAnnouncer.getConfiguration().getAnnouncements().put(strings[1], announcement);
+                AdvancedBungeeAnnouncer.getConfiguration().saveAnnouncements();
                 commandSender.sendMessage(TextComponent.fromLegacyText(ChatColor.GREEN + "New announcement added."));
                 break;
             case "remove":
@@ -86,6 +87,7 @@ public class AnnouncerCommand extends Command
                     return;
                 }
                 AdvancedBungeeAnnouncer.getConfiguration().getAnnouncements().remove(strings[1]);
+                AdvancedBungeeAnnouncer.getConfiguration().saveAnnouncements();
                 commandSender.sendMessage(TextComponent.fromLegacyText(ChatColor.GREEN + "Announcement removed."));
                 break;
             case "list":

--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/config/AnnouncementConfig.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/config/AnnouncementConfig.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Getter
 public class AnnouncementConfig
@@ -88,7 +87,9 @@ public class AnnouncementConfig
 
         for (String key : keys)
         {
-            if (!(announcements.get(key) instanceof Map)) continue;
+            Object object = announcements.get(key);
+            // API was changed to return Configuration instead of Map in BungeeCord commit 98e3c70
+            if (!(object instanceof Map) && !(object instanceof Configuration)) continue;
             Announcement announcement = new Announcement(announcements.getString(key + ".text"));
             announcement.getServers().addAll(announcements.getStringList(key + ".servers"));
             this.announcements.put(key, announcement);


### PR DESCRIPTION
Apparently the plugin has been broken since this commit https://github.com/SpigotMC/BungeeCord/commit/98e3c70460737dcea9dc264882029729b97458e2

Also, I made it not save the config on disable, but instead save when the config is edited through commands. This allows the config to be externally edited without having the changes be overwritten if /announcer reload was not used.