### PR TITLE
Announcement scheduling

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/Announcement.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/Announcement.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class Announcement
 {
     private final String text;
+    private final int beginTimestamp;
     private final int expiryTimestamp;
     private final List<String> servers = new ArrayList<>();
 }

--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/Announcement.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/Announcement.java
@@ -15,5 +15,6 @@ import java.util.List;
 public class Announcement
 {
     private final String text;
+    private final int expiryTimestamp;
     private final List<String> servers = new ArrayList<>();
 }

--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AnnouncerCommand.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AnnouncerCommand.java
@@ -68,7 +68,7 @@ public class AnnouncerCommand extends Command
                 {
                     servers = Collections.singletonList(strings[2]);
                 }
-                Announcement announcement = new Announcement(message);
+                Announcement announcement = new Announcement(message, -1);
                 announcement.getServers().addAll(servers);
                 AdvancedBungeeAnnouncer.getConfiguration().getAnnouncements().put(strings[1], announcement);
                 AdvancedBungeeAnnouncer.getConfiguration().saveAnnouncements();

--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AnnouncerCommand.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AnnouncerCommand.java
@@ -68,7 +68,7 @@ public class AnnouncerCommand extends Command
                 {
                     servers = Collections.singletonList(strings[2]);
                 }
-                Announcement announcement = new Announcement(message, -1);
+                Announcement announcement = new Announcement(message, -1, -1);
                 announcement.getServers().addAll(servers);
                 AdvancedBungeeAnnouncer.getConfiguration().getAnnouncements().put(strings[1], announcement);
                 AdvancedBungeeAnnouncer.getConfiguration().saveAnnouncements();

--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AnnouncingTask.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AnnouncingTask.java
@@ -41,9 +41,6 @@ public class AnnouncingTask implements Runnable
 
         announcements = new ArrayList<>(AdvancedBungeeAnnouncer.getConfiguration().getAnnouncements().values());
 
-        if (announcements.isEmpty())
-            return;
-
         // Discard expired announcements
         Iterator<Announcement> announcementsIterator = announcements.iterator();
         int currentTimestamp = (int) (System.currentTimeMillis() / 1000);
@@ -54,7 +51,14 @@ public class AnnouncingTask implements Runnable
             {
                 announcementsIterator.remove();
             }
+            else if (announcement.getBeginTimestamp() > -1 && announcement.getBeginTimestamp() > currentTimestamp)
+            {
+                announcementsIterator.remove();
+            }
         }
+
+        if (announcements.isEmpty())
+            return;
 
         String prefix = ChatColor.translateAlternateColorCodes('&', AdvancedBungeeAnnouncer.getConfiguration().getPrefix());
 

--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AnnouncingTask.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/AnnouncingTask.java
@@ -39,10 +39,22 @@ public class AnnouncingTask implements Runnable
             return;
         }
 
-        announcements = ImmutableList.copyOf(AdvancedBungeeAnnouncer.getConfiguration().getAnnouncements().values());
+        announcements = new ArrayList<>(AdvancedBungeeAnnouncer.getConfiguration().getAnnouncements().values());
 
         if (announcements.isEmpty())
             return;
+
+        // Discard expired announcements
+        Iterator<Announcement> announcementsIterator = announcements.iterator();
+        int currentTimestamp = (int) (System.currentTimeMillis() / 1000);
+        while (announcementsIterator.hasNext())
+        {
+            Announcement announcement = announcementsIterator.next();
+            if (announcement.getExpiryTimestamp() > -1 && announcement.getExpiryTimestamp() < currentTimestamp)
+            {
+                announcementsIterator.remove();
+            }
+        }
 
         String prefix = ChatColor.translateAlternateColorCodes('&', AdvancedBungeeAnnouncer.getConfiguration().getPrefix());
 
@@ -200,7 +212,7 @@ public class AnnouncingTask implements Runnable
 
         int to;
 
-        if (val + 1 >= AdvancedBungeeAnnouncer.getConfiguration().getAnnouncements().size())
+        if (val + 1 >= announcements.size())
             to = 0;
         else
             to = val + 1;

--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/config/AnnouncementConfig.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/config/AnnouncementConfig.java
@@ -90,7 +90,7 @@ public class AnnouncementConfig
             Object object = announcements.get(key);
             // API was changed to return Configuration instead of Map in BungeeCord commit 98e3c70
             if (!(object instanceof Map) && !(object instanceof Configuration)) continue;
-            Announcement announcement = new Announcement(announcements.getString(key + ".text"));
+            Announcement announcement = new Announcement(announcements.getString(key + ".text"), announcements.getInt(key + ".expiryTimestamp", -1));
             announcement.getServers().addAll(announcements.getStringList(key + ".servers"));
             this.announcements.put(key, announcement);
         }

--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/config/AnnouncementConfig.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/config/AnnouncementConfig.java
@@ -145,6 +145,7 @@ public class AnnouncementConfig
         for (Map.Entry<String, Announcement> entry : announcements.entrySet())
         {
             configuration.set(entry.getKey() + ".text", entry.getValue().getText());
+            configuration.set(entry.getKey() + ".expiryTimestamp", entry.getValue().getExpiryTimestamp());
             configuration.set(entry.getKey() + ".servers", entry.getValue().getServers());
         }
 

--- a/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/config/AnnouncementConfig.java
+++ b/src/main/java/com/imaginarycode/minecraft/advancedbungeeannouncer/config/AnnouncementConfig.java
@@ -90,7 +90,11 @@ public class AnnouncementConfig
             Object object = announcements.get(key);
             // API was changed to return Configuration instead of Map in BungeeCord commit 98e3c70
             if (!(object instanceof Map) && !(object instanceof Configuration)) continue;
-            Announcement announcement = new Announcement(announcements.getString(key + ".text"), announcements.getInt(key + ".expiryTimestamp", -1));
+            Announcement announcement = new Announcement(
+                    announcements.getString(key + ".text"),
+                    announcements.getInt(key + ".beginTimestamp", -1),
+                    announcements.getInt(key + ".expiryTimestamp", -1)
+            );
             announcement.getServers().addAll(announcements.getStringList(key + ".servers"));
             this.announcements.put(key, announcement);
         }
@@ -145,6 +149,7 @@ public class AnnouncementConfig
         for (Map.Entry<String, Announcement> entry : announcements.entrySet())
         {
             configuration.set(entry.getKey() + ".text", entry.getValue().getText());
+            configuration.set(entry.getKey() + ".beginTimestamp", entry.getValue().getBeginTimestamp());
             configuration.set(entry.getKey() + ".expiryTimestamp", entry.getValue().getExpiryTimestamp());
             configuration.set(entry.getKey() + ".servers", entry.getValue().getServers());
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -53,7 +53,7 @@ title:
 # Boss bar configuration.
 bar-display:
   # Colors: PINK, BLUE, RED, GREEN, YELLOW, PURPLE, WHITE
-  color: white
+  color: WHITE
   # Divisions: NONE, SIX, TEN, TWELVE, TWENTY
   # You can _not_ use numbers, you must use these words.
-  division: solid
+  division: NONE


### PR DESCRIPTION
I've added the option to schedule announcements to run (be announced) between specific periods of time. Each announcement can begin and/or end at a specific time.

```java
private final int beginTimestamp;
private final int expiryTimestamp;
```

The new properties are per announcement and optional, they default to `-1` indicating a permanent announcement that should always run. They can be used independently of each other, one can be `-1` (or not defined) and the other one defined that it will work accordingly. E.g announcements.yml:
```yml
# This would make this message start getting announced on
# Thursday, March 7, 2019 10:00:00 AM onwards and be broadcasted for ever.
announcement1:
  text: Test announcement
  beginTimestamp: 1551952800
  expiryTimestamp: -1
  servers:
  - global
# This would make this message start getting announced right away till
# Thursday, March 7, 2019 10:00:00 AM.
announcement1:
  text: Test announcement
  beginTimestamp: -1
  expiryTimestamp: 1551952800
  servers:
  - global
```

I haven't added the expiry to the creation command to avoid over complicating things.

Also, I fixed a default value of the main config file.